### PR TITLE
support deployment to subdirectory

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -3,7 +3,7 @@
 
 <header class="header">
   <nav role="navigation" aria-label="main" class="container">
-    <a href="/" class="logo">
+    <a href={{root-url "/"}} class="logo">
       {{#if guidemaker.logo}}
         <img src={{guidemaker.logo}}>
       {{else}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ember-href-to": "^4.1.0",
         "ember-power-select": "^4.1.3",
         "ember-prism": "^0.5.0",
+        "ember-root-url": "^0.2.0",
         "ember-tether": "^2.0.0",
         "ember-truth-helpers": "^3.0.0",
         "sass": "^1.22.4"
@@ -17450,6 +17451,190 @@
       "version": "0.3.16",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.16.tgz",
       "integrity": "sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg=="
+    },
+    "node_modules/ember-root-url": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ember-root-url/-/ember-root-url-0.2.0.tgz",
+      "integrity": "sha512-VvUCxrcqANOfTAf3p91RAJAyNCIwSmB02NDUUqo1qmmZq+kCszqcuh4g4Dd2RHPTTT+/PQuZP0AACYSu155SXA==",
+      "dependencies": {
+        "ember-cli-babel": "^6.6.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/amd-name-resolver": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+      "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+      "dependencies": {
+        "ensure-posix-path": "^1.0.1"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/babel-plugin-debug-macros": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+      "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+      "dependencies": {
+        "semver": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-beta.42"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/babel-plugin-ember-modules-api-polyfill": {
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+      "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+      "dependencies": {
+        "ember-rfc176-data": "^0.3.13"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/broccoli-babel-transpiler": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+      "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+      "dependencies": {
+        "babel-core": "^6.26.0",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^2.0.0",
+        "broccoli-persistent-filter": "^1.4.3",
+        "clone": "^2.0.0",
+        "hash-for-dep": "^1.2.3",
+        "heimdalljs-logger": "^0.1.7",
+        "json-stable-stringify": "^1.0.0",
+        "rsvp": "^4.8.2",
+        "workerpool": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/broccoli-merge-trees": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+      "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "merge-trees": "^1.0.1"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/broccoli-source": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
+    },
+    "node_modules/ember-root-url/node_modules/ember-cli-babel": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+      "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+      "dependencies": {
+        "amd-name-resolver": "1.2.0",
+        "babel-plugin-debug-macros": "^0.2.0-beta.6",
+        "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-preset-env": "^1.7.0",
+        "broccoli-babel-transpiler": "^6.5.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^2.0.0",
+        "broccoli-source": "^1.1.0",
+        "clone": "^2.0.0",
+        "ember-cli-version-checker": "^2.1.2",
+        "semver": "^5.5.0"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/ember-cli-version-checker": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+      "dependencies": {
+        "resolve": "^1.3.3",
+        "semver": "^5.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/merge-trees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
+      "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+      "dependencies": {
+        "can-symlink": "^1.0.0",
+        "fs-tree-diff": "^0.5.4",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-root-url/node_modules/workerpool": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
+      "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+      "dependencies": {
+        "object-assign": "4.1.1"
+      }
     },
     "node_modules/ember-router-generator": {
       "version": "2.0.0",
@@ -46532,6 +46717,162 @@
       "version": "0.3.16",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.16.tgz",
       "integrity": "sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg=="
+    },
+    "ember-root-url": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ember-root-url/-/ember-root-url-0.2.0.tgz",
+      "integrity": "sha512-VvUCxrcqANOfTAf3p91RAJAyNCIwSmB02NDUUqo1qmmZq+kCszqcuh4g4Dd2RHPTTT+/PQuZP0AACYSu155SXA==",
+      "requires": {
+        "ember-cli-babel": "^6.6.0"
+      },
+      "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "babel-plugin-debug-macros": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
+          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "2.13.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
+          "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
+          "requires": {
+            "ember-rfc176-data": "^0.3.13"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "requires": {
+            "babel-core": "^6.26.0",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.4.3",
+            "clone": "^2.0.0",
+            "hash-for-dep": "^1.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^4.8.2",
+            "workerpool": "^2.3.0"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
+        "broccoli-source": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
+          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
+        },
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+          "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "merge-trees": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
+          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "requires": {
+            "can-symlink": "^1.0.0",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+        },
+        "workerpool": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
+          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+          "requires": {
+            "object-assign": "4.1.1"
+          }
+        }
+      }
     },
     "ember-router-generator": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-href-to": "^4.1.0",
     "ember-power-select": "^4.1.3",
     "ember-prism": "^0.5.0",
+    "ember-root-url": "^0.2.0",
     "ember-tether": "^2.0.0",
     "ember-truth-helpers": "^3.0.0",
     "sass": "^1.22.4"


### PR DESCRIPTION
See https://github.com/empress/guidemaker/issues/19 for context. `{{root-url}}` template helper is a very simple one that prefixes a given URL with the `rootURL` configured in `config/environment.js`.

The template helper is provided by [ember-root-url](https://github.com/ef4/ember-root-url) addon. Wouldn't be that complex to calculate in application controller but adding such a controller would be a breaking change cause consuming application might already have one. I don't see much value of adding the implementation of such a template helper directly to this addon.

This could still be a breaking change if consuming app already has a template helper with a different public API. But I don't think that's very likely.