### PR TITLE
[BREAKING] Remove "scroll to top on click" from <LinkTo> override

### DIFF
--- a/app/components/link-to.js
+++ b/app/components/link-to.js
@@ -3,10 +3,6 @@ import LinkComponent from '@ember/routing/link-component';
 
 export default LinkComponent.extend({
   click() {
-    if(window.scrollTo) {
-      window.scrollTo(0,0);
-    }
-
     if(document) {
       document.getElementById('toc-toggle').checked = false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ember-href-to": "^4.1.0",
         "ember-power-select": "^4.1.3",
         "ember-root-url": "^0.2.0",
+        "ember-showdown-prism": "^2.2.0",
         "ember-tether": "^2.0.0",
         "ember-truth-helpers": "^3.0.0",
         "sass": "^1.22.4"
@@ -46,7 +47,6 @@
         "ember-maybe-import-regenerator": "^0.1.6",
         "ember-qunit": "^5.1.2",
         "ember-resolver": "^8.0.2",
-        "ember-showdown-prism": "^2.2.0",
         "ember-source": "~3.25.1",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^2.18.1",
@@ -56,7 +56,7 @@
         "eslint-plugin-ember": "^10.2.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.3.1",
-        "guidemaker": "^2.3.0",
+        "guidemaker": "^2.6.0",
         "guidemaker-link-checker": "^1.0.0",
         "guidemaker-toc-checker": "^1.0.0",
         "lint-to-the-future": "^0.4.0",
@@ -8392,7 +8392,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz",
       "integrity": "sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=",
-      "dev": true,
       "dependencies": {
         "broccoli-persistent-filter": "^1.1.5",
         "minimatch": "^3.0.3"
@@ -8946,7 +8945,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9453,7 +9451,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -9464,7 +9461,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9473,7 +9469,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -9487,7 +9482,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -10378,7 +10372,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12894,7 +12887,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz",
       "integrity": "sha1-waCKiv+0XJe2dZJicv54z0yhZvI=",
-      "dev": true,
       "engines": {
         "node": ">= 0.10.0"
       }
@@ -12930,7 +12922,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz",
       "integrity": "sha1-0tVWJufMZhn4gtf+VXUfkmYCJwg=",
-      "dev": true,
       "dependencies": {
         "broccoli-funnel": "^1.0.1",
         "broccoli-merge-trees": "^1.1.1",
@@ -12947,7 +12938,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
       "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-      "dev": true,
       "dependencies": {
         "array-equal": "^1.0.0",
         "blank-object": "^1.0.1",
@@ -12969,7 +12959,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
       "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-      "dev": true,
       "dependencies": {
         "broccoli-plugin": "^1.3.0",
         "can-symlink": "^1.0.0",
@@ -12984,14 +12973,12 @@
     "node_modules/ember-cli-node-assets/node_modules/broccoli-source": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-      "dev": true
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
     },
     "node_modules/ember-cli-node-assets/node_modules/fs-tree-diff": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
       "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
       "dependencies": {
         "heimdalljs-logger": "^0.1.7",
         "object-assign": "^4.1.0",
@@ -13003,7 +12990,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13174,7 +13160,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/ember-cli-showdown/-/ember-cli-showdown-4.5.0.tgz",
       "integrity": "sha512-i1XXua2oOqJHGozLw+cXI2zjrfSaamH+qAKt8kLnKTjxDXO175bDUnBtrTR1uMH75S56iIkCBdCSyOMq5haB+g==",
-      "dev": true,
       "dependencies": {
         "broccoli-funnel": "^2.0.0",
         "broccoli-source": "^1.1.0",
@@ -13196,7 +13181,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
       "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-      "dev": true,
       "dependencies": {
         "ensure-posix-path": "^1.0.1"
       }
@@ -13205,7 +13189,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
       "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-      "dev": true,
       "dependencies": {
         "semver": "^5.3.0"
       },
@@ -13220,7 +13203,6 @@
       "version": "2.13.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
       "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
-      "dev": true,
       "dependencies": {
         "ember-rfc176-data": "^0.3.13"
       },
@@ -13232,7 +13214,6 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
       "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-      "dev": true,
       "dependencies": {
         "babel-core": "^6.26.0",
         "broccoli-funnel": "^2.0.1",
@@ -13253,7 +13234,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
       "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
       "dependencies": {
         "array-equal": "^1.0.0",
         "blank-object": "^1.0.1",
@@ -13277,7 +13257,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
       "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-      "dev": true,
       "dependencies": {
         "broccoli-plugin": "^1.3.0",
         "merge-trees": "^1.0.1"
@@ -13286,14 +13265,12 @@
     "node_modules/ember-cli-showdown/node_modules/broccoli-source": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-      "dev": true
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
     },
     "node_modules/ember-cli-showdown/node_modules/ember-cli-babel": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
       "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-      "dev": true,
       "dependencies": {
         "amd-name-resolver": "1.2.0",
         "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -13317,7 +13294,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
       "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
-      "dev": true,
       "dependencies": {
         "broccoli-persistent-filter": "^1.4.3",
         "hash-for-dep": "^1.2.3",
@@ -13332,7 +13308,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
       "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
       "dependencies": {
         "resolve": "^1.3.3",
         "semver": "^5.3.0"
@@ -13345,7 +13320,6 @@
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
       "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dev": true,
       "dependencies": {
         "heimdalljs-logger": "^0.1.7",
         "object-assign": "^4.1.0",
@@ -13357,7 +13331,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
       "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-      "dev": true,
       "dependencies": {
         "can-symlink": "^1.0.0",
         "fs-tree-diff": "^0.5.4",
@@ -13371,7 +13344,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13380,7 +13352,6 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -13389,7 +13360,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
       "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-      "dev": true,
       "dependencies": {
         "object-assign": "4.1.1"
       }
@@ -15170,6 +15140,20 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/ember-decorators-polyfill": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.5.tgz",
+      "integrity": "sha512-O154i8sLoVjsiKzSqxGRfHGr+N+drT6mRrLDbNgJCnW/V5uLg/ppZFpUsrdxuXnp5Q9us3OfXV1nX2CH+7bUpA==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-compatibility-helpers": "^1.2.0"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
     "node_modules/ember-destroyable-polyfill": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
@@ -15261,7 +15245,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
       "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
       "dependencies": {
         "ember-cli-version-checker": "^2.1.0"
       },
@@ -15273,7 +15256,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
       "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
       "dependencies": {
         "resolve": "^1.3.3",
         "semver": "^5.3.0"
@@ -15999,7 +15981,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
       "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
       "dependencies": {
         "ember-cli-version-checker": "^2.1.0",
         "ember-factory-for-polyfill": "^1.3.1"
@@ -16012,7 +15993,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
       "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
       "dependencies": {
         "resolve": "^1.3.3",
         "semver": "^5.3.0"
@@ -17153,7 +17133,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/ember-prism/-/ember-prism-0.8.2.tgz",
       "integrity": "sha512-cGh2z9m7P74sVf89t+WrdS/Uy/bxW8Z3AN7Nas38XyAMivHxfv7LdsdEBedul53/JHYUSujTL+kb/Xjyr/yqQg==",
-      "dev": true,
       "dependencies": {
         "@ember/render-modifiers": "^1.0.2",
         "ember-cli-babel": "^7.19.0",
@@ -17502,11 +17481,24 @@
         "node": "8.* || 10.* || >= 12"
       }
     },
+    "node_modules/ember-scroll": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.3.tgz",
+      "integrity": "sha512-iIB54xrzxpXmXvLfYWD6NrACYuD8o9+DZ4i/8ojd7szOVRp/pdBIm6GSsPcdcI4T2N98RPtquwhM27hvAOPYjA==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.21.0",
+        "ember-cli-htmlbars": "^5.2.0",
+        "ember-decorators-polyfill": "^1.1.5"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
     "node_modules/ember-showdown-prism": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-2.2.0.tgz",
       "integrity": "sha512-zM7IWvF1cayfvrL6fGs9bxObyqGk1aDoVRjTy4syY2fk9Qr45Mrq61bMjqXbI6sNPcFzqZbHpgJ9yAEm/6Yp8Q==",
-      "dev": true,
       "dependencies": {
         "broccoli-funnel": "^3.0.1",
         "ember-cli-babel": "^7.21.0",
@@ -18710,8 +18702,7 @@
     "node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -19631,8 +19622,7 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
       "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
-      "deprecated": "Please replace with usage of fs.existsSync",
-      "dev": true
+      "deprecated": "Please replace with usage of fs.existsSync"
     },
     "node_modules/exit": {
       "version": "0.1.2",
@@ -21390,7 +21380,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -21759,9 +21748,9 @@
       "dev": true
     },
     "node_modules/guidemaker": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/guidemaker/-/guidemaker-2.4.0.tgz",
-      "integrity": "sha512-cCYsYQXfnM4+4vypVuxkJoOW14r9+44bK4gMqkcOxuYPv+tMNU+B3L/HSuvIFZ1HzI9HHYVvMRW0XLLZZ2/P1Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/guidemaker/-/guidemaker-2.6.0.tgz",
+      "integrity": "sha512-ZOv6kAR5Sa3cUBGh/eHRRMVl1+0ZOKOInGFSNYu6r2snuzxZSok7MCKmaJz8Madmt81LVNxZok2QQBiehnjoMQ==",
       "dev": true,
       "dependencies": {
         "broccoli-file-creator": "^2.1.1",
@@ -21776,6 +21765,7 @@
         "ember-cli-showdown": "^4.4.4",
         "ember-get-config": "^0.2.4",
         "ember-meta": "^0.6.1",
+        "ember-scroll": "^1.0.3",
         "empress-blueprint-helpers": "^1.2.0",
         "js-yaml": "^3.13.1",
         "jsonapi-serializer": "^3.6.4",
@@ -23728,7 +23718,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -27954,8 +27943,7 @@
     "node_modules/prismjs": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
-      "dev": true
+      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
     },
     "node_modules/private": {
       "version": "0.1.8",
@@ -28776,7 +28764,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28793,8 +28780,7 @@
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/require-relative": {
       "version": "0.8.7",
@@ -29239,8 +29225,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -29350,7 +29335,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
       "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "dev": true,
       "dependencies": {
         "yargs": "^14.2"
       },
@@ -29371,7 +29355,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -29380,7 +29363,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -29392,7 +29374,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -29405,7 +29386,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -29417,7 +29397,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -29431,7 +29410,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -29443,7 +29421,6 @@
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
       "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-      "dev": true,
       "dependencies": {
         "cliui": "^5.0.0",
         "decamelize": "^1.2.0",
@@ -29462,7 +29439,6 @@
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
       "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-      "dev": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -32353,8 +32329,7 @@
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -32420,7 +32395,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -32434,7 +32408,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -32443,7 +32416,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -32455,7 +32427,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -32463,14 +32434,12 @@
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -32484,7 +32453,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -39801,7 +39769,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz",
       "integrity": "sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=",
-      "dev": true,
       "requires": {
         "broccoli-persistent-filter": "^1.1.5",
         "minimatch": "^3.0.3"
@@ -40212,8 +40179,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "can-symlink": {
       "version": "1.0.0",
@@ -40617,7 +40583,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -40627,14 +40592,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -40645,7 +40608,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -41389,8 +41351,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decimal.js": {
       "version": "10.2.1",
@@ -44044,8 +44005,7 @@
     "ember-cli-import-polyfill": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz",
-      "integrity": "sha1-waCKiv+0XJe2dZJicv54z0yhZvI=",
-      "dev": true
+      "integrity": "sha1-waCKiv+0XJe2dZJicv54z0yhZvI="
     },
     "ember-cli-inject-live-reload": {
       "version": "2.0.2",
@@ -44072,7 +44032,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz",
       "integrity": "sha1-0tVWJufMZhn4gtf+VXUfkmYCJwg=",
-      "dev": true,
       "requires": {
         "broccoli-funnel": "^1.0.1",
         "broccoli-merge-trees": "^1.1.1",
@@ -44086,7 +44045,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
           "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-          "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
             "blank-object": "^1.0.1",
@@ -44108,7 +44066,6 @@
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
           "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "can-symlink": "^1.0.0",
@@ -44123,14 +44080,12 @@
         "broccoli-source": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-          "dev": true
+          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
         },
         "fs-tree-diff": {
           "version": "0.5.9",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
           "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-          "dev": true,
           "requires": {
             "heimdalljs-logger": "^0.1.7",
             "object-assign": "^4.1.0",
@@ -44141,8 +44096,7 @@
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
     },
@@ -44302,7 +44256,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/ember-cli-showdown/-/ember-cli-showdown-4.5.0.tgz",
       "integrity": "sha512-i1XXua2oOqJHGozLw+cXI2zjrfSaamH+qAKt8kLnKTjxDXO175bDUnBtrTR1uMH75S56iIkCBdCSyOMq5haB+g==",
-      "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.0",
         "broccoli-source": "^1.1.0",
@@ -44321,7 +44274,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
           "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.1"
           }
@@ -44330,7 +44282,6 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
           "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
           "requires": {
             "semver": "^5.3.0"
           }
@@ -44339,7 +44290,6 @@
           "version": "2.13.4",
           "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz",
           "integrity": "sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==",
-          "dev": true,
           "requires": {
             "ember-rfc176-data": "^0.3.13"
           }
@@ -44348,7 +44298,6 @@
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
           "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
-          "dev": true,
           "requires": {
             "babel-core": "^6.26.0",
             "broccoli-funnel": "^2.0.1",
@@ -44366,7 +44315,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
           "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
             "blank-object": "^1.0.1",
@@ -44387,7 +44335,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
           "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^1.0.1"
@@ -44396,14 +44343,12 @@
         "broccoli-source": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
-          "dev": true
+          "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
         },
         "ember-cli-babel": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
           "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
-          "dev": true,
           "requires": {
             "amd-name-resolver": "1.2.0",
             "babel-plugin-debug-macros": "^0.2.0-beta.6",
@@ -44424,7 +44369,6 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz",
           "integrity": "sha512-3f3PAxdnQ/fhQa8XP/3z4RLRgLHxV8j4Ln75aHbRdemOCjBa048KxL9l+acRLhCulbGQCMnLiIUIC89PAzLrcA==",
-          "dev": true,
           "requires": {
             "broccoli-persistent-filter": "^1.4.3",
             "hash-for-dep": "^1.2.3",
@@ -44436,7 +44380,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -44446,7 +44389,6 @@
           "version": "0.5.9",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
           "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-          "dev": true,
           "requires": {
             "heimdalljs-logger": "^0.1.7",
             "object-assign": "^4.1.0",
@@ -44458,7 +44400,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
           "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
-          "dev": true,
           "requires": {
             "can-symlink": "^1.0.0",
             "fs-tree-diff": "^0.5.4",
@@ -44471,20 +44412,17 @@
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "rsvp": {
           "version": "4.8.5",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
         },
         "workerpool": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
           "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
           "requires": {
             "object-assign": "4.1.1"
           }
@@ -45359,6 +45297,17 @@
         }
       }
     },
+    "ember-decorators-polyfill": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.5.tgz",
+      "integrity": "sha512-O154i8sLoVjsiKzSqxGRfHGr+N+drT6mRrLDbNgJCnW/V5uLg/ppZFpUsrdxuXnp5Q9us3OfXV1nX2CH+7bUpA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-version-checker": "^3.1.3",
+        "ember-compatibility-helpers": "^1.2.0"
+      }
+    },
     "ember-destroyable-polyfill": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
@@ -45428,7 +45377,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
       "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dev": true,
       "requires": {
         "ember-cli-version-checker": "^2.1.0"
       },
@@ -45437,7 +45385,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -46040,7 +45987,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
       "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dev": true,
       "requires": {
         "ember-cli-version-checker": "^2.1.0",
         "ember-factory-for-polyfill": "^1.3.1"
@@ -46050,7 +45996,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
           "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
@@ -46978,7 +46923,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/ember-prism/-/ember-prism-0.8.2.tgz",
       "integrity": "sha512-cGh2z9m7P74sVf89t+WrdS/Uy/bxW8Z3AN7Nas38XyAMivHxfv7LdsdEBedul53/JHYUSujTL+kb/Xjyr/yqQg==",
-      "dev": true,
       "requires": {
         "@ember/render-modifiers": "^1.0.2",
         "ember-cli-babel": "^7.19.0",
@@ -47261,11 +47205,21 @@
         "recast": "^0.18.1"
       }
     },
+    "ember-scroll": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-scroll/-/ember-scroll-1.0.3.tgz",
+      "integrity": "sha512-iIB54xrzxpXmXvLfYWD6NrACYuD8o9+DZ4i/8ojd7szOVRp/pdBIm6GSsPcdcI4T2N98RPtquwhM27hvAOPYjA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.21.0",
+        "ember-cli-htmlbars": "^5.2.0",
+        "ember-decorators-polyfill": "^1.1.5"
+      }
+    },
     "ember-showdown-prism": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-2.2.0.tgz",
       "integrity": "sha512-zM7IWvF1cayfvrL6fGs9bxObyqGk1aDoVRjTy4syY2fk9Qr45Mrq61bMjqXbI6sNPcFzqZbHpgJ9yAEm/6Yp8Q==",
-      "dev": true,
       "requires": {
         "broccoli-funnel": "^3.0.1",
         "ember-cli-babel": "^7.21.0",
@@ -48230,8 +48184,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -48934,8 +48887,7 @@
     "exists-sync": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
-      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
-      "dev": true
+      "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk="
     },
     "exit": {
       "version": "0.1.2",
@@ -50400,8 +50352,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -50723,9 +50674,9 @@
       "dev": true
     },
     "guidemaker": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/guidemaker/-/guidemaker-2.4.0.tgz",
-      "integrity": "sha512-cCYsYQXfnM4+4vypVuxkJoOW14r9+44bK4gMqkcOxuYPv+tMNU+B3L/HSuvIFZ1HzI9HHYVvMRW0XLLZZ2/P1Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/guidemaker/-/guidemaker-2.6.0.tgz",
+      "integrity": "sha512-ZOv6kAR5Sa3cUBGh/eHRRMVl1+0ZOKOInGFSNYu6r2snuzxZSok7MCKmaJz8Madmt81LVNxZok2QQBiehnjoMQ==",
       "dev": true,
       "requires": {
         "broccoli-file-creator": "^2.1.1",
@@ -50740,6 +50691,7 @@
         "ember-cli-showdown": "^4.4.4",
         "ember-get-config": "^0.2.4",
         "ember-meta": "^0.6.1",
+        "ember-scroll": "^1.0.3",
         "empress-blueprint-helpers": "^1.2.0",
         "js-yaml": "^3.13.1",
         "jsonapi-serializer": "^3.6.4",
@@ -52288,8 +52240,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-git-url": {
       "version": "1.0.0",
@@ -55740,8 +55691,7 @@
     "prismjs": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
-      "dev": true
+      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
     },
     "private": {
       "version": "0.1.8",
@@ -56396,8 +56346,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -56408,8 +56357,7 @@
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "require-relative": {
       "version": "0.8.7",
@@ -56765,8 +56713,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -56854,7 +56801,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
       "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "dev": true,
       "requires": {
         "yargs": "^14.2"
       },
@@ -56862,14 +56808,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
           }
@@ -56878,7 +56822,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -56888,7 +56831,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
           "requires": {
             "p-limit": "^2.0.0"
           }
@@ -56897,7 +56839,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -56908,7 +56849,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -56917,7 +56857,6 @@
           "version": "14.2.3",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
           "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-          "dev": true,
           "requires": {
             "cliui": "^5.0.0",
             "decamelize": "^1.2.0",
@@ -56936,7 +56875,6 @@
           "version": "15.0.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
           "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -59337,8 +59275,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.3",
@@ -59394,7 +59331,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -59404,14 +59340,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -59420,7 +59354,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -59428,14 +59361,12 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -59446,7 +59377,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-ember": "^10.2.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "guidemaker": "^2.3.0",
+    "guidemaker": "^2.6.0",
     "guidemaker-link-checker": "^1.0.0",
     "guidemaker-toc-checker": "^1.0.0",
     "lint-to-the-future": "^0.4.0",


### PR DESCRIPTION
This makes use of the fact that [Guidemaker v2.6.0](https://github.com/empress/guidemaker/releases/tag/v2.6.0) includes [ember-scroll](https://github.com/simplabs/ember-scroll) by default so we don't need a custom implementation of "scroll to top" 

This is marked as "breaking" because you need to make sure that you have at least empress@2.6 to have similar scroll behaviour if you upgrade to this version of the template 👍 